### PR TITLE
Enhancement to remove button

### DIFF
--- a/ui/src/components/Editor.js
+++ b/ui/src/components/Editor.js
@@ -82,6 +82,10 @@ const Editor = (props) => {
     setSampleURIs(sampleURIs.concat(contentURI));
   };
 
+  const removeURI = (contentURI) => {
+    setSampleURIs((prevURIs) => prevURIs.filter((uri) => uri !== contentURI));
+  };
+
   // View management (start)
   const handleViewChange = (viewIndex, changedView) => {
     let template = templateJSON;
@@ -340,6 +344,7 @@ const Editor = (props) => {
           <SampleDocs
             uris={sampleURIs}
             addURI={addURI}
+            removeURI={removeURI}
             authHeaders={buildAuthHeaders()}
             contentDB={selectedContentDb}
           />

--- a/ui/src/components/SampleDocs.js
+++ b/ui/src/components/SampleDocs.js
@@ -4,7 +4,7 @@ import { FlexBox } from './Box';
 import { TextEdit } from './TextEdit';
 import { Button } from './Button';
 
-const SampleDocs = ({ uris, addURI, contentDB, authHeaders }) => {
+const SampleDocs = ({ uris, addURI, removeURI, contentDB, authHeaders }) => {
   const [currentURI, setCurrentURI] = useState('');
   const [currentViewedDoc, setCurrentViewedDoc] = useState('');
 
@@ -15,6 +15,11 @@ const SampleDocs = ({ uris, addURI, contentDB, authHeaders }) => {
   const handleAddURI = () => {
     addURI(currentURI);
     setCurrentURI('');
+  };
+
+  const handleRemoveURI = (uri) => {
+    removeURI(uri); // Remove the URI from the list
+    setCurrentViewedDoc('');
   };
 
   const viewDoc = (uri) => {
@@ -49,9 +54,9 @@ const SampleDocs = ({ uris, addURI, contentDB, authHeaders }) => {
         </FlexBox>
         {uris.map((uri) => (
           <FlexBox key={uri} gap="1rem" alignItems="flex-end">
-            <TextEdit label="URI" value={uri} onChange={() => {}} rootStyle={{ flexGrow: 1 }} />
+            <TextEdit disabled label="URI" value={uri} onChange={() => {}} rootStyle={{ flexGrow: 1 }} />
             <Button onClick={(e) => viewDoc(uri)}>View</Button>
-            <Button danger>Remove</Button>
+            <Button danger onClick={(e) => handleRemoveURI(uri)}>Remove</Button>
           </FlexBox>
         ))}
 


### PR DESCRIPTION
The 'Remove' button was not yet functional. Implemented support to clear out the row and conent of uri upon clicking the 'Remove' button. Also made the uris read-only to avoid cunfusion to the end user.

<img width="1037" alt="Remove_Button" src="https://github.com/user-attachments/assets/51c589c1-03d9-43e5-b927-5b73000a0f67" />
