### PR TITLE
28: Added support for viewing the URIs in scope

### DIFF
--- a/examples/soccer/src/main/ml-schemas/tde/soccer.json
+++ b/examples/soccer/src/main/ml-schemas/tde/soccer.json
@@ -2,6 +2,7 @@
   "template": {
     "context": "/match",
     "collections": ["soccer"],
+    "directories": ["/soccer/"],
     "vars": [
       {
         "name": "prefix",

--- a/marklogic/src/main/ml-modules/root/api/tde/uris.sjs
+++ b/marklogic/src/main/ml-modules/root/api/tde/uris.sjs
@@ -66,11 +66,7 @@ function getUris() {
   const getTotalCount = () => {
     return xdmp.invokeFunction(
       function () {
-        return fn.count(cts.uris(
-          '',
-          ['ascending'],
-          cts.andQuery([finalCollectionsQuery, finalDirectoryQuery, finalContextQuery])
-        ));
+        return cts.estimate(cts.andQuery([finalCollectionsQuery, finalDirectoryQuery, finalContextQuery]));
       },
       { database: contentDBId }
     );

--- a/marklogic/src/main/ml-modules/root/api/tde/uris.sjs
+++ b/marklogic/src/main/ml-modules/root/api/tde/uris.sjs
@@ -10,14 +10,36 @@ function getUris() {
 
   let page = xdmp.getRequestField('page');
   let pageSize = xdmp.getRequestField('pageSize');
-  let finalCollectionsQuery;
+  let totalCount = xdmp.getRequestField('totalCount');
+  let contentDB = xdmp.getRequestField('contentDB');
 
   page = page === null ? 1 : page;
-  pageSize = pageSize === null ? 20 : pageSize;
+  pageSize = pageSize === null ? 10 : pageSize;
+
+  const getDatabaseId = (dbName) => {
+    try {
+      return xdmp.database(dbName);
+    } catch (e) {
+      return errorResponse(
+        400,
+        'Invalid Database',
+        `${dbName} is not the name of a database in this MarkLogic instance`
+      );
+    }
+  };
+
+  if (contentDB === undefined || contentDB === null || fn.empty(contentDB)) {
+    return errorResponse(400, 'MISSING-PARAMETER', '"contentDB" is a required parameter');
+  }
+
+  let contentDBId = getDatabaseId(contentDB);
 
   let templateObj = xdmp.toJSON(template).toObject().template,
     collections = templateObj.collections,
-    directories = templateObj.directories;
+    directories = templateObj.directories,
+    context = templateObj.context;
+
+  let finalCollectionsQuery;
   if (collections !== undefined && collections !== null && !fn.empty(collections)) {
     let uniCollections = collections.filter((collection) => !collection.collectionsAnd),
       andCollections = collections.filter((collection) => collection.collectionsAnd),
@@ -32,15 +54,46 @@ function getUris() {
   if (directories !== undefined && directories !== null && !fn.empty(directories)) {
     finalDirectoryQuery = cts.directoryQuery(directories, 'infinity');
   }
+  let finalContextQuery;
+  if (context !== undefined && context !== null && !fn.empty(context)) {
+    let elements = context.split('/').filter(e => e);
+    finalContextQuery = cts.trueQuery();
+    for (let i = elements.length - 1; i >= 0; i--) {
+      finalContextQuery = cts.jsonPropertyScopeQuery(`${elements[i]}`, finalContextQuery);
+    }
+  }
 
-  return cts.uris(
-    '',
-    ['map', 'skip=' + (page - 1) * pageSize, 'truncate=' + pageSize],
-    cts.andQuery([finalCollectionsQuery, finalDirectoryQuery])
+  const getTotalCount = () => {
+    return xdmp.invokeFunction(
+      function () {
+        return fn.count(cts.uris(
+          '',
+          ['ascending'],
+          cts.andQuery([finalCollectionsQuery, finalDirectoryQuery, finalContextQuery])
+        ));
+      },
+      { database: contentDBId }
+    );
+  };
+
+  totalCount = Number(totalCount) === 0 ? getTotalCount() : totalCount;
+
+  let uris = xdmp.invokeFunction(
+    function () {
+      return fn.subsequence(cts.uris(
+        '',
+        ['ascending'],
+        cts.andQuery([finalCollectionsQuery, finalDirectoryQuery, finalContextQuery])
+      ), (1 + ((page - 1) * pageSize)), pageSize);
+    },
+    { database: contentDBId }
   );
+
+  return { totalCount: totalCount, uris: Array.from(uris) };
+
 }
 
 runModule(getUris, {
-  allowedMethods: 'get',
+  allowedMethods: 'post',
   protected: true
 });

--- a/ui/src/components/Editor.js
+++ b/ui/src/components/Editor.js
@@ -16,7 +16,8 @@ function defaultTemplate() {
   return {
     template: {
       context: '',
-      collections: []
+      collections: [],
+      directories: []
     }
   };
 }
@@ -74,6 +75,12 @@ const Editor = (props) => {
   const handleCollectionChange = (collection) => {
     let template = templateJSON;
     template.template.collections = [collection];
+    setTemplateJSON(template);
+  };
+
+  const handleDirectoryChange = (directory) => {
+    let template = templateJSON;
+    template.template.directories = [directory];
     setTemplateJSON(template);
   };
   // Template Management (end)
@@ -335,11 +342,13 @@ const Editor = (props) => {
             templateURI={selectedTemplateURI}
             context={templateJSON.template.context}
             collection={templateJSON.template.collections}
+            directory={templateJSON.template.directories}
             description={templateJSON.template.description}
             handleURIChange={handleURIChange}
             handleDescriptionChange={handleDescriptionChange}
             handleContextChange={handleContextChange}
             handleCollectionChange={handleCollectionChange}
+            handleDirectoryChange={handleDirectoryChange}
           />
           <SampleDocs
             uris={sampleURIs}
@@ -347,6 +356,7 @@ const Editor = (props) => {
             removeURI={removeURI}
             authHeaders={buildAuthHeaders()}
             contentDB={selectedContentDb}
+            template={templateJSON}
           />
           <Variables
             variables={templateJSON.template.vars}

--- a/ui/src/components/SampleDocs.js
+++ b/ui/src/components/SampleDocs.js
@@ -1,13 +1,62 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Group } from './Group';
 import { FlexBox } from './Box';
 import { TextEdit } from './TextEdit';
 import { Button } from './Button';
+import { Select } from './Select';
 
-const SampleDocs = ({ uris, addURI, removeURI, contentDB, authHeaders }) => {
+const SampleDocs = ({ uris, addURI, removeURI, contentDB, authHeaders, template }) => {
   const [currentURI, setCurrentURI] = useState('');
   const [currentViewedDoc, setCurrentViewedDoc] = useState('');
   const [currentViewedURI, setCurrentViewedURI] = useState('');
+  const [availableURIs, setAvailableURIs] = useState([]);
+  const [selectUri, setSelectUri] = useState('');
+  const [page, setPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const pageSize = 10;
+
+  useEffect(() => {
+    //have added this condition based on the initial empty template object in the application
+    //assuming that a template will have at least collection or context or directory
+    if (template && (template.template.context !== '' ||
+      (template.template.collections && template.template.collections.length > 0) ||
+      (template.template.directories && template.template.directories.length > 0))) {
+      fetchURIs(1);
+    }
+  }, [template]);
+
+  const fetchURIs = (pageNum) => {
+    fetch(`${process.env.REACT_APP_API_URL || ''}/tde/uris?contentDB=${contentDB}&page=${pageNum}&pageSize=${pageSize}&totalCount=${totalCount}`, {
+      method: 'POST',
+      headers: {
+        ...authHeaders,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(template)
+    })
+      .then((res) => res.json())
+      .then((result) => {
+        const newURIs = result.uris || [];
+        setAvailableURIs(newURIs);
+        setTotalCount(result.totalCount || 0);
+        setPage(pageNum);
+      })
+      .catch((error) => console.error('Error fetching URIs:', error));
+  };
+
+  const totalPages = totalCount > 0 ? Math.ceil(totalCount / pageSize) : 1;
+
+  const handleNextPage = () => {
+    if (page < totalPages) {
+      fetchURIs(page + 1);
+    }
+  };
+
+  const handlePrevPage = () => {
+    if (page > 1) {
+      fetchURIs(page - 1);
+    }
+  };
 
   const handleURIChange = (uri) => {
     setCurrentURI(uri);
@@ -17,6 +66,7 @@ const SampleDocs = ({ uris, addURI, removeURI, contentDB, authHeaders }) => {
     if (currentURI !== '') {
       addURI(currentURI);
       setCurrentURI('');
+      setSelectUri('');
     }
   };
 
@@ -79,7 +129,21 @@ const SampleDocs = ({ uris, addURI, removeURI, contentDB, authHeaders }) => {
       <FlexBox flexDirection="column" gap="1rem" alignItems="stretch">
         <FlexBox alignItems="flex-end" gap="1rem">
           <TextEdit label="URI" value={currentURI} onChange={handleURIChange} rootStyle={{ flexGrow: 1 }} />
-          <Button onClick={(e) => handleAddURI()}>Add</Button>
+          <Select
+            label={totalCount > 0 ? `Select URI (Page ${page} of ${totalPages})` : 'Select URI (No pages)'}
+            options={availableURIs
+              .sort()
+              .map(uri => ({ label: uri, value: uri }))}
+            value={selectUri}
+            onChange={(selectedUri) => {
+              setCurrentURI(selectedUri);
+              setSelectUri(selectedUri);
+            }}
+            onOpen={() => fetchURIs(page)}
+          />
+          <Button onClick={handlePrevPage} disabled={page <= 1}>Previous</Button>
+          <Button onClick={handleNextPage} disabled={page >= totalPages}>Next</Button>
+          <Button onClick={handleAddURI}>Add</Button>
         </FlexBox>
         {uris.map((uri) => (
           <FlexBox key={uri} gap="1rem" alignItems="flex-end">

--- a/ui/src/components/Template.js
+++ b/ui/src/components/Template.js
@@ -10,6 +10,8 @@ const Template = ({
   description,
   handleCollectionChange,
   collection,
+  handleDirectoryChange,
+  directory,
   handleContextChange,
   context
 }) => {
@@ -19,7 +21,7 @@ const Template = ({
         <TextEdit label="URI" value={templateURI} onChangeDebounced={handleURIChange} />
         <TextEdit label="Description" type="textarea" rows={3} value={description} onChange={handleDescriptionChange} />
         <TextEdit label="Collection" value={collection} onChange={handleCollectionChange} />
-        <TextEdit label="Directory" placeholder={''} onChange={() => {}} />
+        <TextEdit label="Directory" value={directory} onChange={handleDirectoryChange} />
         <TextEdit label="Context" value={context} onChange={handleContextChange} />
       </FlexBox>
     </Group>


### PR DESCRIPTION
Have added a drop-down select for URIs in scope. The editor will look like below when it loads, showing currently 'no pages':

<img width="1323" alt="Screenshot 2025-03-06 at 13 41 45" src="https://github.com/user-attachments/assets/452e0e34-4581-4700-ae8e-90e6ed6fe5d3" />

Once we select the TDE it will load the first page of the documents based on page-size(I have take 2 for showcase purpose). It will show the 'Page x of y' on the drop-down label. Also the 'previous button' will be disabled to make sure that there are no wrong calls to the API:

<img width="1340" alt="Screenshot 2025-03-06 at 13 42 17" src="https://github.com/user-attachments/assets/3af1e089-44b2-4984-b0b0-b22c9c6cec13" />

At the last page the 'next button' will be disabled, again to make sure that there are no wrong calls to the API:

<img width="1332" alt="Screenshot 2025-03-06 at 13 42 41" src="https://github.com/user-attachments/assets/a23d4aac-7b57-47c9-ab76-c38a18327409" />
